### PR TITLE
Add UnipoolBalanceProxy

### DIFF
--- a/contracts/UnipoolBalanceProxy.sol
+++ b/contracts/UnipoolBalanceProxy.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "./Unipool.sol";
+
+contract UnipoolBalanceProxy {
+    using SafeERC20 for IERC20;
+
+    IERC20 public tradedToken = IERC20(0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9);
+    Unipool public pool;
+
+    constructor(Unipool _pool) public {
+        pool = _pool;
+    }
+
+    function transfer() public {
+      tradedToken.safeIncreaseAllowance(address(pool), tradedToken.balanceOf(address(this)));
+      pool.notifyRewardAmount(tradedToken.balanceOf(address(this)));
+    }
+}

--- a/contracts/UnipoolFactory.sol
+++ b/contracts/UnipoolFactory.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./Unipool.sol";
+import "./UnipoolBalanceProxy.sol";
 
 contract UnipoolFactory {
     mapping(address => address) public pools;

--- a/contracts/UnipoolFactory.sol
+++ b/contracts/UnipoolFactory.sol
@@ -7,10 +7,16 @@ contract UnipoolFactory {
     mapping(address => address) public pools;
 
     function createUnipool(
-        IERC20 _uniswapTokenExchange
-    ) public view returns (address) {
+        address _uniswapTokenExchange
+    ) public returns (address) {
         require(pools[_uniswapTokenExchange] == address(0), "Pool already exists.");
-        pools[_uniswapTokenExchange] = new Unipool(_uniswapTokenExchange);
+        pools[_uniswapTokenExchange] = address(
+            new Unipool(IERC20(_uniswapTokenExchange))
+        );
+
+        // NOTICE(onbjerg): This is temporary until conviction voting can
+        // call `Unipool#notifyRewardAmount` itself
+        new UnipoolBalanceProxy(Unipool(pools[_uniswapTokenExchange]));
 
         return pools[_uniswapTokenExchange];
     }

--- a/contracts/mock/UnipoolBalanceProxyMock.sol
+++ b/contracts/mock/UnipoolBalanceProxyMock.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.0;
+
+import "../../contracts/UnipoolBalanceProxy.sol";
+
+contract UnipoolBalanceProxyMock is UnipoolBalanceProxy {
+
+    constructor(Unipool _pool, IERC20 _tradedToken) UnipoolBalanceProxy(_pool) public {
+        tradedToken = _tradedToken;
+    }
+}

--- a/test/UnipoolBalanceProxy.js
+++ b/test/UnipoolBalanceProxy.js
@@ -1,0 +1,27 @@
+const { BN, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const UniswapToken = artifacts.require('UniswapTokenMock');
+const TradedToken = artifacts.require('HoneyTokenMock');
+const Unipool = artifacts.require('UnipoolMock');
+const UnipoolBalanceProxy = artifacts.require('UnipoolBalanceProxyMock');
+
+contract('UnipoolFactory', function ([_, wallet1, wallet2, wallet3, wallet4]) {
+    describe('UnipoolFactory', async function () {
+        beforeEach(async function () {
+            this.uniswapToken = await UniswapToken.new();
+            this.tradedToken = await TradedToken.new(wallet1);
+            this.pool = await Unipool.new(this.uniswapToken.address, this.tradedToken.address);
+            this.proxy = await UnipoolBalanceProxy.new(this.pool.address, this.tradedToken.address);
+
+            await this.tradedToken.mint(wallet1, web3.utils.toWei('1000'));
+            await this.tradedToken.transfer(this.proxy.address, web3.utils.toWei('1000'), { from: wallet1 });
+        });
+
+        it('transfers its balances to the pool', async function () {
+            await this.proxy.transfer()
+            expect(await this.tradedToken.balanceOf(this.pool.address)).to.be.bignumber.equal(web3.utils.toWei('1000'));
+            expect(await this.tradedToken.balanceOf(this.proxy.address)).to.be.bignumber.equal('0');
+        });
+    });
+});

--- a/test/UnipoolFactory.js
+++ b/test/UnipoolFactory.js
@@ -14,7 +14,7 @@ contract('UnipoolFactory', function ([_, wallet1, wallet2, wallet3, wallet4]) {
         });
 
         it('creates a new Unipool for a given LP token', async function () {
-            expect(await this.factory.createUnipool(this.uniswapToken.address)).to.be.a('string');
+            await this.factory.createUnipool(this.uniswapToken.address);
         });
 
         it('does not allow duplicate Unipools', async function () {

--- a/test/UnipoolFactory.js
+++ b/test/UnipoolFactory.js
@@ -14,12 +14,12 @@ contract('UnipoolFactory', function ([_, wallet1, wallet2, wallet3, wallet4]) {
         });
 
         it('creates a new Unipool for a given LP token', async function () {
-            await this.factory.createUnipool(this.uniswapToken.address);
+            expect(await this.factory.createUnipool(this.uniswapToken.address)).to.be.a('string');
         });
 
         it('does not allow duplicate Unipools', async function () {
-            await this.factory.createUnipool(this.uniswapToken.address);
-            await expectRevert(this.factory.createUnipool(this.uniswapToken.address), 'Pool already exists.');
+            expect(await this.factory.createUnipool(this.uniswapToken.address)).to.be.a('string');
+            expectRevert(await this.factory.createUnipool(this.uniswapToken.address), 'Pool already exists.');
         });
     });
 });

--- a/test/UnipoolFactory.js
+++ b/test/UnipoolFactory.js
@@ -18,8 +18,8 @@ contract('UnipoolFactory', function ([_, wallet1, wallet2, wallet3, wallet4]) {
         });
 
         it('does not allow duplicate Unipools', async function () {
-            expect(await this.factory.createUnipool(this.uniswapToken.address)).to.be.a('string');
-            expectRevert(await this.factory.createUnipool(this.uniswapToken.address), 'Pool already exists.');
+            await this.factory.createUnipool(this.uniswapToken.address);
+            await expectRevert(this.factory.createUnipool(this.uniswapToken.address), 'Pool already exists.');
         });
     });
 });


### PR DESCRIPTION
Requires #2 

Adds a balance proxy that we can send funds to from CV. This contract just holds funds and routes them to the Unipool when the `transfer` method is called.