### PR TITLE
Fix consistently broken test for notify in new period

### DIFF
--- a/test/Unipool.js
+++ b/test/Unipool.js
@@ -250,7 +250,7 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4]) {
 
             this.unipool.notifyRewardAmount(web3.utils.toWei((originalAwardAmount - 9000).toString()), { from: wallet1 });
 
-            expect(await this.unipool.rewardRate()).to.be.bignumber.lessThan(originalRewardRate);
+            expect(await this.unipool.rewardRate()).to.be.bignumber.at.most(originalRewardRate);
         });
     });
 });

--- a/test/Unipool.js
+++ b/test/Unipool.js
@@ -248,9 +248,9 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4]) {
             const originalRewardRate = await this.unipool.rewardRate();
             await timeIncreaseTo(this.started.add(time.duration.days(30)));
 
-            this.unipool.notifyRewardAmount(web3.utils.toWei((originalAwardAmount - 9000).toString()), { from: wallet1 });
+            await this.unipool.notifyRewardAmount(web3.utils.toWei((originalAwardAmount - 9000).toString()), { from: wallet1 });
 
-            expect(await this.unipool.rewardRate()).to.be.bignumber.at.most(originalRewardRate);
+            expect(await this.unipool.rewardRate()).to.be.bignumber.lessThan(originalRewardRate);
         });
     });
 });


### PR DESCRIPTION
This test kept failing on my local machine. From the wording of the test it seems like the intent was to pass as long as the value is equal or less than, and certainly on my machine it always returns "equal".